### PR TITLE
Fix stop_cluster to properly clean up HTCondor jobs

### DIFF
--- a/src/htcdaskgateway/cluster.py
+++ b/src/htcdaskgateway/cluster.py
@@ -48,6 +48,7 @@ class HTCGatewayCluster(GatewayCluster):
         self.scheduler_proxy_ip = kwargs.pop('', '131.225.218.222')
         self.batchWorkerJobs = []
         self.image_registry = image_registry
+        self.is_shutdown = False
         self.cluster_options = kwargs.get('cluster_options')
         self.apptainer_image = apptainer_image
         self.worker_memory = None
@@ -89,6 +90,10 @@ class HTCGatewayCluster(GatewayCluster):
 
         self.status = "closed"
 
+    def shutdown(self):
+        self.is_shutdown = True
+        super().shutdown()
+
     def scale(self, n, **kwargs):
         """Scale the cluster to ``n`` workers.
         Parameters
@@ -104,6 +109,9 @@ class HTCGatewayCluster(GatewayCluster):
         worker_type = 'htcondor'
         logger.warn(" worker_type: "+str(worker_type))
 
+        if self.is_shutdown:
+            logger.warning("Cluster was shutdown - cannot scale!")
+            return
         current_jobs = sum(x['n_jobs'] for x in self.batchWorkerJobs)
 
         if n == current_jobs:
@@ -124,7 +132,7 @@ class HTCGatewayCluster(GatewayCluster):
                 while to_remove > 0 and self.batchWorkerJobs:
                     cluster = self.batchWorkerJobs[-1]
                     if cluster['n_jobs'] <= to_remove:
-                        # remove whole cluster
+                        # remove whole condor cluster
                         self._destroy_batch_cluster(cluster)
                         self.batchWorkerJobs.pop()
                         to_remove -= cluster['n_jobs']
@@ -273,7 +281,7 @@ dask worker --name $2 --tls-ca-file /etc/dask-credentials/dask.crt --tls-cert /e
             logger.info("Removed cluster %s: %s", cluster['ClusterId'], result.decode().rstrip())
 
         except Exception as e:
-            logger.error("Failed to remove cluster %s: %s", cluster.get('ClusterId'), exc)
+            logger.error("Failed to remove cluster %s: %s", cluster.get('ClusterId'), e)
 
     def _remove_jobs_in_cluster(self, cluster, n):
         q_cmd = f"condor_q {cluster['ClusterId']} -af ProcId"
@@ -305,7 +313,8 @@ dask worker --name $2 --tls-ca-file /etc/dask-credentials/dask.crt --tls-cert /e
                 result = subprocess.check_output(['sh','-c',cmd], cwd=htc_cluster['Iwd'])
                 logger.info(" "+result.decode().rstrip())
             except:
-                logger.info(" "+result.decode().rstrip())
+                logger.error("Failed to remove HTCondor cluster %s", htc_cluster.get('ClusterId'))
+        self.batchWorkerJobs = []
 
     def adapt(self, minimum=None, maximum=None, active=True, **kwargs):
         """Configure adaptive scaling for the cluster.

--- a/src/htcdaskgateway/gateway.py
+++ b/src/htcdaskgateway/gateway.py
@@ -99,9 +99,27 @@ class HTCGateway(Gateway):
         return self.sync(self._scale_cluster, cluster_name, n, **kwargs)
     
     async def _stop_cluster(self, cluster_name):
+        # Find the existing cluster object to trigger its HTCondor shutdown
+        # sequence before deleting via the API.
+        for cluster in list(HTCGatewayCluster._instances):
+            if cluster.name == cluster_name:
+                cluster.is_shutdown = True
+                # Use _stop_internal() rather than _stop_async() directly so
+                # that deduplication and gateway session cleanup are handled
+                # correctly by the parent class.  shutdown=False because we
+                # issue the DELETE ourselves below.
+                await cluster._stop_internal(shutdown=False)
+                break
+        else:
+            logger.warning(
+                "stop_cluster: cluster %s not found in active instances; "
+                "HTCondor jobs may need manual cleanup.",
+                cluster_name,
+            )
+
+        # Delete via API
         url = f"{self.address}/api/v1/clusters/{cluster_name}"
         await self._request("DELETE", url)
-        HTCGatewayCluster.from_name(cluster_name).close(shutdown=True)
 
     def stop_cluster(self, cluster_name, **kwargs):
         """Stop a cluster.


### PR DESCRIPTION
Add an is_shutdown flag to disallow scaling up clusters that were shut down.

Also, instead of calling close(shutdown=False) which tries to use sync() from an async context (causing a hang), we now call `_stop_async()` directly. This triggers:
1. `destroy_all_batch_clusters()` for HTCondor cleanup
2. `super()._stop_async()` for other cleanup

The API DELETE happens separately after.